### PR TITLE
remove match sorting

### DIFF
--- a/search/matcher.go
+++ b/search/matcher.go
@@ -3,7 +3,6 @@ package mediasearch
 import (
 	"fmt"
 	"log"
-	"sort"
 )
 
 // DefaultThreshold for matching names. 100 is a perfect match.
@@ -35,11 +34,11 @@ func (m *matcher) bestMatch() (Result, error) {
 	if len(m.resultSlice) == 0 {
 		return Result{}, fmt.Errorf("No results")
 	}
-	sort.Sort(m)
+	//sort.Sort(m)
 	if debugMode {
 		log.Println("Matched results:")
 		for i, r := range m.resultSlice {
-			log.Printf("#%d: %s", i, r)
+			log.Printf("#%d: %s (%v)", i, r, r.Accuracy)
 		}
 	}
 	r := m.resultSlice[0]

--- a/search/search.go
+++ b/search/search.go
@@ -8,7 +8,7 @@ import (
 	"github.com/fatih/color"
 )
 
-const debugMode = false
+const debugMode = true
 
 //search function interface
 type search func(string, string, MediaType) ([]Result, error)


### PR DESCRIPTION
I'm not sure if it is a good solution. 
I tested with some tv shows and movies and it works. TVMaze best results are at the end of slice. So I removed your sorting. 
Maybe you find a better way. 