### PR TITLE
Enable folder sorting

### DIFF
--- a/sort/strings.go
+++ b/sort/strings.go
@@ -19,7 +19,7 @@ var (
 	extRe           = regexp.MustCompile(`\.\w+$`)
 	apost           = regexp.MustCompile(`'`)
 	colon           = regexp.MustCompile(`:`)
-	invalidChars    = regexp.MustCompile(`[^a-zA-Z0-9\_\-\.\ \(\)]`)
+	invalidChars    = regexp.MustCompile(`[^a-zA-Z0-9\_\-\.\ \(\)\/\\]`)
 	doubleDash      = regexp.MustCompile(`-(\s*-\s*)+ `)
 	doubleSpace     = regexp.MustCompile(`\s+`)
 )


### PR DESCRIPTION
Fixes #1 #2 and #6

Usage example:
```
media-sort --recursive --movie-template "{{ .Name }}/{{ .Name }} ({{ .Year }}).{{ .Ext }}" --tv-template '{{ .Name }}/Season {{ printf "%02d" .Season }}/{{ .Name }} S{{ printf "%02d" .Season }}E{{ printf "%02d" .Episode }}{{ if ne .ExtraEpisode -1 }}-{{ printf "%02d" .ExtraEpisode }}{{end}}.{{ .Ext }}' -t ~/gdrive/Plex/TV/ -m ~/gdrive/Plex/Movies/ ~/gdrive/Plex/Unsorted/
```