### PR TITLE
Add an 'mv' action which bangs out to '/bin/mv' to avoid bogus 'cross-device' issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ $ media-sort --help
   --recursive, -r           also search through subdirectories
   --dry-run, -d             perform sort but don't actually move any files
   --skip-hidden, -s         skip dot files
-  --action                  filesystem action used to sort files (copy|link|move, default move)
+  --action                  filesystem action used to sort files (copy|link|move|mv, default move)
   --hard-link, -h           use hardlinks instead of symlinks (forces --action link)
   --overwrite, -o           overwrites duplicates
   --overwrite-if-larger     overwrites duplicates if the new file is larger


### PR DESCRIPTION
I appreciate this is likely to be controversial, so I understand if you don't want to merge it.

This commit adds a new `mv` action (`--action`). It simply execs `/bin/mv`.

The reason for this is that on BTRFS subvolumes (which my NAS uses), the Go `os.Rename()` call returns "invalid cross-device link", so the `move()` function falls back to making a new copy of the file and then deleting the original.

However, attempting the same move via the command line `mv` util works instantly. It turns out the BTRFS can make a copy-on-write copy of the file even though it's moving the file between sub-volumes. The `mv` util initially attempts a `rename()` syscall (which is the same as Go's `os.Rename()`), but if it gets `EXDEV` back then it falls back to making an `ioctl` call to make a copy-on-write copy. 

The impact of this is that when moving large (4K) movies or whole TV series between BTRFS subvolumes, media-sort can take a very long time, while `mv` works instantly.

I've raised a bug report in Go (which has been effectively converted to an enhancement request): https://github.com/golang/go/issues/41487. In the meantime, this PR is a stop-gap measure.