### PR TITLE
Move all matching .srt files

### DIFF
--- a/sort/fs_sort.go
+++ b/sort/fs_sort.go
@@ -294,10 +294,10 @@ func (fs *fsSort) sortFile(file *fileSort) error {
 		return fmt.Errorf("Invalid result type: %s", result.MType)
 	}
 	newPath = filepath.Join(baseDir, newPath)
-	//check for subs.srt file
+	//check for subs.en.srt file
 	hasSubs := false
 	subsExt := ""
-	pathSubs := strings.TrimSuffix(result.Path, filepath.Ext(result.Path)) + ".srt"
+	pathSubs := strings.TrimSuffix(result.Path, filepath.Ext(result.Path)) + ".en.srt"
 	if fs.SkipSubs == false {
 		_, err = os.Stat(pathSubs)
 		hasSubs = err == nil
@@ -336,9 +336,9 @@ func (fs *fsSort) sortFile(file *fileSort) error {
 	if err != nil {
 		return err //failed to move
 	}
-	//if .srt file exists for the file, action it too
+	//if .en.srt file exists for the file, action it too
 	if hasSubs {
-		newPathSubs := strings.TrimSuffix(newPath, filepath.Ext(newPath)) + ".srt"
+		newPathSubs := strings.TrimSuffix(newPath, filepath.Ext(newPath)) + ".en.srt"
 		fs.action(pathSubs, newPathSubs) //best-effort
 	}
 	return nil

--- a/sort/fs_sort.go
+++ b/sort/fs_sort.go
@@ -298,19 +298,18 @@ func (fs *fsSort) sortFile(file *fileSort) error {
 	subsFiles := []string{}
 	subsExt := ""
 
-	pathDir := filepath.Dir(result.Path)
-	files, err := ioutil.ReadDir(pathDir)
+	originalPathDir := filepath.Dir(result.Path)
+	originalPathDirFiles, err := ioutil.ReadDir(originalPathDir)
 	if err != nil {
 		return err
 	}
 	// add all .srt subs found in the same folder to be moved
 	if fs.SkipSubs == false {
-		for _, file := range files {
+		for _, adjacentFile := range originalPathDirFiles {
 			originalFileName := filepath.Base(strings.TrimSuffix(result.Path, filepath.Ext(result.Path)))
 
-			if strings.HasPrefix(file.Name(), originalFileName) && strings.HasSuffix(file.Name(), ".srt") {
-				tempSubsPath := pathDir + "/" + file.Name()
-				subsFiles = append(subsFiles, tempSubsPath)
+			if strings.HasPrefix(adjacentFile.Name(), originalFileName) && strings.HasSuffix(adjacentFile.Name(), ".srt") {
+				subsFiles = append(subsFiles, originalPathDir+"/"+adjacentFile.Name())
 			}
 		}
 	}

--- a/sort/fs_sort.go
+++ b/sort/fs_sort.go
@@ -298,13 +298,14 @@ func (fs *fsSort) sortFile(file *fileSort) error {
 	subsFiles := []string{}
 	subsExt := ""
 
-	originalPathDir := filepath.Dir(result.Path)
-	originalPathDirFiles, err := ioutil.ReadDir(originalPathDir)
-	if err != nil {
-		return err
-	}
 	// add all .srt subs found in the same folder to be moved
 	if fs.SkipSubs == false {
+		originalPathDir := filepath.Dir(result.Path)
+		originalPathDirFiles, err := ioutil.ReadDir(originalPathDir)
+		if err != nil {
+			return err
+		}
+
 		for _, adjacentFile := range originalPathDirFiles {
 			originalFileName := filepath.Base(strings.TrimSuffix(result.Path, filepath.Ext(result.Path)))
 

--- a/sort/fs_sort.go
+++ b/sort/fs_sort.go
@@ -348,7 +348,7 @@ func (fs *fsSort) sortFile(file *fileSort) error {
 	if err != nil {
 		return err //failed to move
 	}
-	//if .srt files exists for the file, action them too
+	//if .srt files exist for the file, action them too
 	if len(subsFiles) > 0 {
 		for _, pathSubs := range subsFiles {
 			targetSuffix := strings.Replace(pathSubs, strings.TrimSuffix(result.Path, filepath.Ext(result.Path)), "", 1)

--- a/sort/fs_sort.go
+++ b/sort/fs_sort.go
@@ -348,7 +348,7 @@ func (fs *fsSort) sortFile(file *fileSort) error {
 	if err != nil {
 		return err //failed to move
 	}
-	//if .srt files exists for the file, action it too
+	//if .srt files exists for the file, action them too
 	if len(subsFiles) > 0 {
 		for _, pathSubs := range subsFiles {
 			targetSuffix := strings.Replace(pathSubs, strings.TrimSuffix(result.Path, filepath.Ext(result.Path)), "", 1)


### PR DESCRIPTION
Since loads of applications (including Plex) allow for several `.srt` files with different languages/options (`.en.srt`, `.forced.srt`, etc) I thought it would be nice if those files could be included as subs when sorting.

RIght now the logic is that it checks the original directory of the result, and checks adjacent files for files that start with the name of the file, and end with `.srt`.
Any files that match the above criteria is considered a subtitle file that belongs with the result in question, and is moved along with it.